### PR TITLE
Possible race condition in `next`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "inherits": "^2.0.3",
+    "mutexify": "^1.2.0",
     "readable-stream": "^2.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
While `hyperdb` benchmarking, I've been running into a similar issue to https://github.com/mafintosh/hyperdb/issues/73, and I think it has to do with a race condition in `next`. 

If `next` is called twice in quick succession with an empty callback queue, one of those callbacks can overwrite `self._nextCallback`, but a `nextDone` callback is registered twice if `this._open` is called twice. The problem lies here: https://github.com/mafintosh/nanoiterator/blob/c0f965065e6b02b839a8d6ef89991225a859f840/index.js#L28

It's assumed that every time `nextDone` is called, there is either an immediate `self._nextCallback` available, or one in the queue. In the above scenario, the first callback will be executed in `nextDone`, but then `self._nextCallback` will be nullified without popping the second callback from the queue (because it was never inserted). https://github.com/mafintosh/nanoiterator/blob/c0f965065e6b02b839a8d6ef89991225a859f840/index.js#L68

Does that sound right? Adding a lock will serialize writes to the queue, but it does make things less nano. 